### PR TITLE
Allow spawn() to call .run()

### DIFF
--- a/private/connection.nim
+++ b/private/connection.nim
@@ -52,7 +52,7 @@ when defined(debug):
   var L {.threadvar.}: ConsoleLogger
   L = newConsoleLogger()
 
-proc `$`*(q: Query): string =
+proc `$`*(q: Query): string {.thread.} =
   var j = newJArray()
   j.add(newJInt(q.kind.ord))
 
@@ -235,7 +235,7 @@ when not compileOption("threads"):
     await r.connect()
 
 else:
-  proc runQuery(r: RethinkClient, q: Query, token: uint64 = 0): int =
+  proc runQuery(r: RethinkClient, q: Query, token: uint64 = 0): int {.thread.} =
     when defined(debug):
       L.log(lvlDebug, "Sending query: $#" % [$q])
     var token = token

--- a/private/datum.nim
+++ b/private/datum.nim
@@ -6,9 +6,9 @@ import base64
 import types
 import ql2
 
-proc toJson*(r: RqlQuery): JsonNode
+proc toJson*(r: RqlQuery): JsonNode {.thread.}
 
-proc `%`*(m: MutableDatum): JsonNode =
+proc `%`*(m: MutableDatum): JsonNode {.thread.} =
   if m.isNil:
     return newJNull()
   case m.kind

--- a/private/rql.nim
+++ b/private/rql.nim
@@ -120,7 +120,7 @@ else:
             timeFormat = "native", profile = false, durability = "hard", groupFormat = "native",
             noreply = false, db = "", arrayLimit = 100_000, binaryFormat = "native",
             minBatchRows = 8, maxBatchRows = 0, maxBatchBytes = 0, maxBatchSeconds = 0.5,
-            firstBatchScaleDownFactor = 4): JsonNode =
+            firstBatchScAleDownFactor = 4): JsonNode {.thread.} =
     ## Run a query on a connection, returning a `JsonNode` contains single JSON result or an JsonArray, depending on the query.
     var c = c
     if c.isNil:


### PR DESCRIPTION
I suspect that this is merely the tip of the iceberg,
but without the {.thread.} pragma's, the following code
inside a spawned function will fail;

var ret = r.table("user").get(getStr(id)).run()

during compilation with --threads:on as it's "not GC-safe"
Addresses #6 